### PR TITLE
README.mdのエンドポイントパスとページ内リンクの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![Dependabot Updates](https://github.com/futaringoto/futarin-api/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/futaringoto/futarin-api/actions/workflows/dependabot/dependabot-updates)
 
 ## 目次
-- [貢献者ガイド(CONTRIBUTING.md)](#貢献者ガイド(CONTRIBUTING.md))
-- [動作環境](#動作環境)
+- [貢献者ガイド(CONTRIBUTING.md)](#貢献者ガイドcontributingmd)
+- [動作環境（確認済み）](#動作環境確認済み)
 - [動作確認](#動作確認)
-- [APIエンドポイント(v1)](#APIエンドポイント(v1))
+- [APIエンドポイント(v1)](#apiエンドポイントv1)
 - [ディレクトリ構成](#ディレクトリ構成)
-- [VOICEVOX](#VOICEVOX)
+- [VOICEVOX](#voicevox)
 - [ライセンス](#ライセンス)
 
 ## 貢献者ガイド(CONTRIBUTING.md)
@@ -56,16 +56,16 @@ http://localhost/docs
 sudo make stop
 ```
 
-## APIエンドポイント(v1)
+## APIエンドポイントv1
 詳しくは https://futaringoto.github.io/futarin-api/ を参照してください。
 | メソッド | パス | 概要 |
 | :----- | :-- | :-- |
-| POST | `/v1/raspi` | 一連の処理全て |
-| POST | `/v1/sandbox/gpt` | ChatGPTによる文章生成 |
-| POST | `/v1/sandbox/transcript` | whisperによる文字起こし |
+| POST | `/v1/raspi/` | 一連の処理全て |
+| POST | `/v1/sandbox/gpt/` | ChatGPTによる文章生成 |
+| POST | `/v1/sandbox/transcript/` | whisperによる文字起こし |
 
 > [!WARNING]
-> 従来の`/raspi/xxx`系のエンドポイントはdeprecated(非推奨)となりました。
+> 従来の`/raspi/xxx/`系のエンドポイントはdeprecated(非推奨)となりました。
 
 ## `make`コマンドについて
 本リポジトリは`Makefile`を採用しています。


### PR DESCRIPTION
## 概要

エンドポイントパスが間違っていたので修正。

ついでに目次のページ内リンクが効かなかったので修正した。

## 関連タスク

Close #94  (required)

## やったこと

- エンドポイント表のパスを修正
- 目次のページ内リンクを適切にHeadingに飛ぶように修正

## やらないこと

## レビュー事項

- ちゃんと目次のリンクが張れているか確認

## 補足 参考情報

README.mdのみの変更なのでテストは実行していません。

### 参考記事

https://note.com/koki_nineteen/n/nfb81a9a39809

https://qiita.com/hennin/items/7ee58dd7d7c013a23be7
