### PR TITLE
makefileでrunからexecに

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ stop: ## コンテナ停止
 test: ## テスト
 	@if [ "$(CHECK_CONTAINER)" = "true" ]; then \
 		echo "Container $(CONTAINER_NAME) is running. Running your command..."; \
-		docker compose run --entrypoint "pytest" api; \
+		docker compose exec $(CONTAINER_NAME) pytest; \
 	else \
 		echo "Container $(CONTAINER_NAME) is not running."; \
 	fi
@@ -33,7 +33,7 @@ test: ## テスト
 lint: ## リント
 	@if [ "$(CHECK_CONTAINER)" = "true" ]; then \
 		echo "Container $(CONTAINER_NAME) is running. Running your command..."; \
-			docker compose run --entrypoint "flake8" api; \
+		docker compose exec $(CONTAINER_NAME) flake8; \
 	else \
 		echo "Container $(CONTAINER_NAME) is not running."; \
 	fi
@@ -42,8 +42,8 @@ lint: ## リント
 format: ## フォーマット
 	@if [ "$(CHECK_CONTAINER)" = "true" ]; then \
 		echo "Container $(CONTAINER_NAME) is running. Running your command..."; \
-		docker compose run --entrypoint "black ." api; \
-		docker compose run --entrypoint "flake8 " api; \
+		docker compose exec $(CONTAINER_NAME) black .; \
+		docker compose exec $(CONTAINER_NAME) flake8; \
 	else \
 		echo "Container $(CONTAINER_NAME) is not running."; \
 	fi


### PR DESCRIPTION
## 概要
静的解析やコード整形を`docker compose run `から`exec`に変更した。
基本的にコンテナは開発時に常時稼働させている前提と考えたため。

## 関連タスク
Close #102  (required)

## やったこと
- 静的解析やコード整形を`docker compose run `から`exec`に変更した

## やらないこと
- CIの修正 （#103 で行う）

## レビュー事項
-

## 補足 参考情報


