### PR TITLE
ci.ymlのrunをexecに

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run docker-compose Build
         run: docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build -d
       - name: Run flake8
-        run: docker compose run --entrypoint "flake8" api
+        run: docker compose exec api flake8
 
       - name: Run test
-        run: docker compose run --entrypoint "pytest" api
+        run: docker compose exec api pytest


### PR DESCRIPTION
## 概要
ci.yml にて、`docker compose up --build`しているにもかかわらず、`docker compose run`をテストと静的解析で2回も行っており、効率が悪かった

## 関連タスク
Close #103  (required)

## やったこと
- `docker compose run`を`exec`に変更した

## やらないこと


## レビュー事項
-

## 補足 参考情報


