### PR TITLE
schemaの引数をjson_schema_extraに変更

### DIFF
--- a/api/v1/schemas/sandbox.py
+++ b/api/v1/schemas/sandbox.py
@@ -2,4 +2,4 @@ from pydantic import BaseModel, Field
 
 
 class TextResponse(BaseModel):
-    text: str = Field(None, example="文字列だけ返します。")
+    text: str = Field(None, json_schema_extra={"example": "文字列だけ返します。"})


### PR DESCRIPTION
## 概要

chatgptより
> このエラーは、Pydanticのバージョン2.0以降で、Fieldの引数としてexampleなどの追加のキーワード引数を使用することが非推奨になったことに起因しています。代わりに、json_schema_extraを使用する必要があります。

## 関連タスク
Close #104  (required)

## やったこと
- `v1/services/gpt.py`のexample をjson_schema_extraに変更

## やらないこと


## レビュー事項
-

## 補足 参考情報


