### PR TITLE
--build-argsを指定してビルド

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
       - name: 'Compose Customized Docker Image'
         run: |
           docker buildx build --platform linux/amd64,linux/arm64 \
+            --build-args ENV=production \
             -f ./_docker/api/Dockerfile \
             -t ${{ vars.LOGIN_SERVER }}/${{ env.IMAGE }}:${{ github.sha }} \
             --push .


### PR DESCRIPTION
## 概要
ARGを設定せずに、デプロイ前のビルドを行おうとしてエラーが発生していた。

## 関連タスク
Close #93 (required)

## やったこと
`--build-args=production`でビルドするよう`deploy.yml`を変更

## やらないこと


## レビュー事項
-

## 補足 参考情報


