### PR TITLE
db関係のREADME修正とmake create-tableの追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,15 @@ run-dev-d: ## コンテナ起動（デタッチ）
 stop: ## コンテナ停止
 	docker compose down
 
+.PHONY: create-table
+create-table: ## テーブル作成
+	@if [ "$(CHECK_CONTAINER)" = "true" ]; then \
+		echo "Container $(CONTAINER_NAME) is running. Running your command..."; \
+		docker compose exec $(CONTAINER_NAME) python migrate_db.py; \
+	else \
+		echo "Container $(CONTAINER_NAME) is not running."; \
+	fi
+
 .PHONY: test
 test: ## テスト
 	@if [ "$(CHECK_CONTAINER)" = "true" ]; then \

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ cd futarin-api
 touch .env
 echo "VOICEVOX_API_KEY=[voicevox api key]" >> .env
 echo "OPENAI_API_KEY=[openAI api key]" >> .env
+echo "MYSQL_DATABASE=futaringoto_db" >> .env
 echo "MYSQL_ROOT_PASSWORD=password" >> .env
 ```
 `VOICEVOX_API_KEY` は https://su-shiki.com/api/ から、
 `OPENAI_API_KEY` は https://platform.openai.com/docs/overview から取得します
-`MYSQL_ROOT_PASSWORD` は開発用の任意のパスワードを設定します。
 
 3. Dockerイメージのビルド
 ```
@@ -50,10 +50,16 @@ sudo make run-dev
 # Detachモード
 sudo make run-dev-d
 ```
-5. localhost でドキュメントを開いてみましょう
+
+5. テーブル作成
+```
+sudo make create-table
+```
+
+6. localhost でドキュメントを開いてみましょう
 http://localhost/docs
 
-6. コンテナの停止
+7. コンテナの停止
 ```
 sudo make stop
 ```
@@ -81,7 +87,7 @@ sudo make stop
 | Make | 実行する処理 | 元のコマンド |
 | :--- | :-------- | :-------- |
 | `make build` | コンテナのビルド | `docker compose -f docker-compose.yml -f docker-compose.dev.yml build` |
-| `make build-no-build` | コンテナのビルド(キャッシュなし) | `docker compose -f docker-compose.yml -f docker-compose.dev.yml build --no-build` |
+| `make build-no-cache` | コンテナのビルド(キャッシュなし) | `docker compose -f docker-compose.yml -f docker-compose.dev.yml build --no-cache` |
 | `make run-dev` | コンテナの起動 | `docker compose -f docker-compose.yml -f docker-compose.dev.yml up` |
 | `make run-dev-d` | コンテナの起動（デタッチ） | `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d` |
 | `make stop` | コンテナの停止 | `docker compose down` |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sudo make stop
 | `make lint` | リントの実行 | `docker compose exec api flake8` |
 | `make format` | フォーマットの実行 | `docker compose exec api black .` `docker compose exec api isort .` |
 | `make test` | テストの実行 | `docker compose exec api pytest` |
-
+| `make create-table` | テーブルの作成 | `docker compose exec api python migrate_db.py` |
 
 ## ディレクトリ構成
 - api (application - FastAPI)


### PR DESCRIPTION
## 概要


## 関連タスク
Close #136   (required)

## やったこと
- README.md の、`make build-no-cache`が`make build-no-build`になっているtypoを修正
- .env の内容追加 `MYSQL_DATABASE`
- dbのテーブル作成の手順説明
- テーブル作成コマンドのMakefile化 `make create-table`とか？

## やらないこと


## レビュー事項
-

## 補足 参考情報


