### PR TITLE
mysqlのwarningに対処

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       MYSQL_ROOT_PASSWORD: "password"
       MYSQL_DATABASE: "futaringoto_db"
       TZ: "Asia/Tokyo"
+    cap_add:
+      - SYS_NICE
     volumes:
       - db-data:/var/lib/mysql
       # - ./_docker/db/my.cnf:/etc/mysql/conf.d/my.cnf


### PR DESCRIPTION
## 概要
テーブル操作するたびに、warning が発生する。

## 関連タスク
Close #132   (required)

## やったこと
- docker-compose.yml に以下を追記
```yaml
services:
  db:
    :
    env_file:
      - .env
    cap_add: # 追加
      - SYS_NICE
```

## やらないこと


## レビュー事項
-

## 補足 参考情報


